### PR TITLE
split token from api ingress

### DIFF
--- a/wso2-am/templates/ingress.yaml
+++ b/wso2-am/templates/ingress.yaml
@@ -1,22 +1,22 @@
-{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "self.fullname" . -}}
+{{- if .Values.ingress.apiServer.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-api
   labels:
 {{ include "self.labels" . | indent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.apiServer.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if .Values.ingress.apiServer.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.apiServer.ingressClassName }}
 {{- end }}
-{{- if .Values.ingress.tls }}
+{{- if .Values.ingress.apiServer.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.ingress.apiServer.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
@@ -25,7 +25,46 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range .Values.ingress.apiServer.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path | quote }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ .servicePort | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}  
+---
+{{- if .Values.ingress.tokenServer.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-token
+  labels:
+{{ include "self.labels" . | indent 4 }}
+  {{- with .Values.ingress.tokenServer.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tokenServer.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.tokenServer.ingressClassName }}
+{{- end }}
+{{- if .Values.ingress.tokenServer.tls }}
+  tls:
+  {{- range .Values.ingress.tokenServer.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.tokenServer.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/wso2-am/values.yaml
+++ b/wso2-am/values.yaml
@@ -84,20 +84,35 @@ copyExtHostToEtcHosts:
   extHostName: wso2exthostname
 
 ingress:
-  enabled: false
-  annotations: {}
+  apiServer:
+    enabled: false
+    annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
+    hosts:
+    - host: extgw.local
       paths:
         - path: "/"
           servicePort: wso2
+    tls: []
+      # - secretName: extgw-tls
+      #   hosts:
+      #     - ${ingress_host}
+  tokenServer:
+    enabled: false
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    hosts:
+    - host: token-extgw.local
+      paths:
+        - path: "/"
+          servicePort: wso2https
+    tls: []
+      # - secretName: extgw-tls
+      #   hosts:
+      #     - ${ingress_host}
 
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 secret:
   externalSecretVolMountEnabled: false


### PR DESCRIPTION
allows for separate config of token and api ingresses for tls purposes (client auth, etc)